### PR TITLE
[FIX] 'project.task' object has no attribute 'is_fsm'

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -40,6 +40,7 @@ class ProjectTask(models.Model):
     project_sale_order_id = fields.Many2one('sale.order', string="Project's sale order", related='project_id.sale_order_id')
     invoice_count = fields.Integer("Number of invoices", related='sale_order_id.invoice_count')
     task_to_invoice = fields.Boolean("To invoice", compute='_compute_task_to_invoice', search='_search_task_to_invoice', groups='sales_team.group_sale_salesman_all_leads')
+    is_fsm = fields.Boolean('Is FSM', default=False, readonly=True)
 
     @api.depends('project_id.sale_line_id.order_partner_id')
     def _compute_partner_id(self):


### PR DESCRIPTION
Fixing Value Error above. is_fsm is a enterprise field not available in Community Version.

ValueError: <class 'AttributeError'>: "'project.task' object has no attribute 'is_fsm'" while evaluating
'model._cron_create_recurring_tasks()'

Description of the issue/feature this PR addresses:

Recurrent Tasks do not work because of is_fsm field

Current behavior before PR:

Recurrent Tasks do not work because of is_fsm field

Desired behavior after PR is merged:

is_fsm as placeholder field and recurring tasks are created




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
